### PR TITLE
doc: Enhance brillig documentation around Stop, Return, and Foreign Call

### DIFF
--- a/docs/brillig/02_opcode_listing.md
+++ b/docs/brillig/02_opcode_listing.md
@@ -219,7 +219,7 @@ Return
 
 - ## ForeignCall
 
-This opcode is used to get data from an external source. It works similarly to a low-level syscall in C-like programming architectures, interfacing with the outer system in a way that interrupts the program and updates its memory or registers. From the semantics of execution, and especially proving, it is as if we had an input that we stored that was simply copied when we hit the foreign call.
+This opcode is used to get data from an external source. It works similarly to a low-level syscall in C-like programming architectures, interfacing with the outer system in a way that interrupts the program and updates its memory or registers. From the semantics of execution and proving, it is as if we had an input that we stored that was simply copied when we hit the foreign call. A simulation pass may indeed store these results, and a later prover simply would consider the opcode as a copy of these results to memory or registers.
 
 ForeignCall is used whenever the outer system would better handle data, or in the case of a VM, possibly a constraint unknown to Brillig.
 It is meant to be used generally for any case that an external system needs to interleave with a Noir program. This varies from printing, to setting data in a database. It requires a function name that is interpreted by the simulator context, a destination register to store the result, and an input register containing the input data. These can be either memory registers (i.e. pointers with a length) or value registers. 

--- a/docs/brillig/03_example.md
+++ b/docs/brillig/03_example.md
@@ -11,96 +11,109 @@ fn main() {
     c = a + b;
     
     if c <= 15 {
-        a = a * 2;
+        a = a * b;
     } else {
-        b = b * 2;
+        b = a + b;
     }
     
     print(a, b, c);
 }
 ```
 
-We may output the following Brillig:
+One possible Brillig output would be:
 
 ```
 [
-    {
+    { // location = 0
         "Const": {
             "destination": 0,
             "value": { "inner": "10" }
         }
     },
-    {
+    { // location = 1
         "Const": {
             "destination": 1,
             "value": { "inner": "5" }
         }
     },
-    {
+    { // location = 2
         "Const": {
             "destination": 2,
             "value": { "inner": "0" }
         }
     },
-    {
-        "BinaryFieldOp": {
+    { // location = 3
+        "Const": {
+            "destination": 3,
+            "value": { "inner": "15" }
+        }
+    },
+    { // location = 4
+        "BinaryIntOp": {
             "destination": 2,
+            "op": "Add",
+            "bit_size": 32,
+            "lhs": 0,
+            "rhs": 1
+        }
+    },
+    { // location = 5
+        "BinaryIntOp": {
+            "destination": 4,
+            "op": "LessThanEquals",
+            "bit_size": 32,
+            "lhs": 2,
+            "rhs": 3
+        }
+    },
+    { // location = 6
+        "JumpIfNot": {
+            "condition": 4,
+            "location": 9
+        }
+    },
+    { // location = 7
+        "BinaryFieldOp": {
+            "destination": 0,
+            "op": "Multiply",
+            "lhs": 0,
+            "rhs": 1
+        }
+    },
+    { // location = 8
+        "Jump": {
+            "location": 10
+        }
+    },
+    { // location = 9
+        "BinaryFieldOp": {
+            "destination": 1,
             "op": "Add",
             "lhs": 0,
             "rhs": 1
         }
     },
-    {
-        "BinaryIntOp": {
-            "destination": 3,
-            "op": "LessThanEquals",
-            "bit_size": 32,
-            "lhs": 2,
-            "rhs": 4
-        }
-    },
-    {
-        "JumpIfNot": {
-            "condition": 3,
-            "location": 8
-        }
-    },
-    {
-        "BinaryFieldOp": {
-            "destination": 0,
-            "op": "Multiply",
-            "lhs": 0,
-            "rhs": 5
-        }
-    },
-    {
-        "Jump": {
-            "location": 10
-        }
-    },
-    {
-        "BinaryFieldOp": {
-            "destination": 1,
-            "op": "Multiply",
-            "lhs": 1,
-            "rhs": 5
-        }
-    },
-    {
+    { // location = 10
         "ForeignCall": {
             "function": "print",
-            "destination": {
-                "RegisterIndex": 6 // Arbitrary, not used
-            },
-            "input": {
-                "RegisterIndex": 0,
-                "RegisterIndex": 1,
-                "RegisterIndex": 2
-            }
+            "destination": [], // No output
+            "input": [
+                {"RegisterIndex": 0},
+                {"RegisterIndex": 1},
+                {"RegisterIndex": 2}
+            ]
         }
     },
-    {
+    { // location = 11
         "Stop": {}
     }
 ]
 ```
+
+The execution and interpretation of the program would be as follows:
+1. The three `Const` instructions load values into reg0, reg1, reg2, reg3. These are variables a, b and c, and a temporary equal to 15
+2. At location 4, let reg2 (c) equal reg0 plus reg1 (a + b)
+3. Let reg4 (a temporary value) equal reg2 LessThanEquals reg3 (c <= 15)
+4. If reg4 is 0 (so c > 15), jump to location 9 where we set b = a + b then go to location 10. Otherwise if c <= 15, we fall through to location 7, set a = a * b, and then go to location 10.
+5. At location 10, we queue up inputs to a foreign call from reg0, reg1, reg2 (variables a, b, and c). This interrupts execution, calls to the outer system, and then returns to Brillig execution. If this had outputs, they might be written to registers and memory.
+6. We finally reach the final location where we `Stop`. If this were a function to be called by another Brillig function, we would `Return`.


### PR DESCRIPTION
Resolves (https://github.com/noir-lang/acvm-docs/issues/6)
Adds documentation per title

# PR Checklist\*

- [*] I have tested the changes locally.
- [*] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
